### PR TITLE
docs: sync SECURITY_CI with Stripe v13; add CI Truth Table; link evid…

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -48,3 +48,14 @@ After implementing the starter pack:
 4. **Audit Preparation**: Use the framework to prepare for formal compliance audits
 
 For questions about specific compliance requirements or implementation guidance, consult with your legal and security teams.
+
+
+## Continuous Integration (CI) and Security
+
+Our CI pipeline includes automated security checks to ensure the integrity and security of our codebase. For a detailed breakdown of these checks, see the **CI Truth Table** in our [SECURITY_CI.md](./SECURITY_CI.md#ci-truth-table) documentation.
+
+### Evidence Locations
+
+- **CI Run Logs**: Detailed logs for each CI run are available in the **Actions** tab of the GitHub repository.
+- **Test Artifacts**: Test reports and other artifacts are available for download from the summary page of each CI run.
+

--- a/docs/SECURITY_CI.md
+++ b/docs/SECURITY_CI.md
@@ -285,8 +285,23 @@ if: false  # Emergency bypass - remove after fix
 
 ## 📝 Recent Changes
 
-- **December 2024**: Stripe pinned to `~=12.5.1` temporarily; 13.x upgrade coming in a follow-up PR with billing portal compatibility tests.  
-- **December 2024**: Prepared Stripe 13.x (`~=13.0.1`) upgrade with enhanced billing portal tests. *This will be merged after staging validation; until then the pin remains on `main`.*
+- **December 2024**: Stripe upgraded to `~=13.0.1`, validated in staging, and merged to main.
+
+## CI Truth Table
+
+This table documents the automated checks enforced by our CI pipeline on every pull request.
+
+| Check | Where Enforced | Fails PR? | Evidence Location |
+|---|---|---|---|
+| **Python 3.11 Setup** | `.github/workflows/ci.yaml` | ✅ Yes | CI run logs |
+| **Dependency Cache** | `.github/workflows/ci.yaml` | ❌ No | CI run logs |
+| **`pytest` Smoke Tests** | `.github/workflows/ci.yaml` | ✅ Yes | CI run logs, test artifacts |
+| **`flake8` Syntax Lint** | `.github/workflows/ci.yaml` | ❌ No | CI run logs (informational) |
+| **`black --check`** | `.github/workflows/ci.yaml` | ❌ No | CI run logs (informational) |
+| **`markdownlint`** | `.github/workflows/docs-lint.yml` | ✅ Yes | CI run logs |
+| **Semgrep (SAST)** | `.github/workflows/ci-security.yml` | ✅ Yes | CI run logs |
+| **Gitleaks (Secrets)** | `.github/workflows/ci-security.yml` | ✅ Yes | CI run logs |
+| **OWASP Dependency Check** | `.github/workflows/ci-security.yml` | ✅ Yes | CI run logs, test artifacts |
 
 ---
 

--- a/docs/compliance/controls-matrix.md
+++ b/docs/compliance/controls-matrix.md
@@ -12,7 +12,7 @@ This document maps Brikk's implemented security controls to the relevant require
 | **HMAC Authentication** | 164.312(a)(2)(iv) - Person or entity authentication<br>164.312(c)(1) - Integrity | CC6.1 - Logical and physical access controls<br>CC8.1 - Change management | All API requests are authenticated using HMAC signatures to ensure the integrity and authenticity of the data. |
 | **Idempotency** | 164.312(c)(1) - Integrity | CC7.1 - System operations | All state-changing API requests are idempotent to prevent duplicate transactions and ensure data integrity. |
 | **Observability** | 164.312(b) - Audit controls | CC7.2 - Monitoring of controls | Comprehensive logging and monitoring of all systems and applications to detect and respond to security incidents in a timely manner. |
-| **CI/CD Security Scans** | 164.308(a)(1)(ii)(A) - Risk analysis<br>164.308(a)(1)(ii)(B) - Risk management | CC7.1 - System operations<br>CC8.1 - Change management | Automated security scanning in the CI/CD pipeline (SAST, SCA, secret detection) to identify and remediate vulnerabilities before they are deployed to production. |
+| **CI/CD Security Scans** | 164.308(a)(1)(ii)(A) - Risk analysis<br>164.308(a)(1)(ii)(B) - Risk management | CC6.1 - Logical and physical access controls<br>CC7.1 - System operations<br>CC7.2 - Monitoring of controls<br>CC7.3 - Responds to security incidents<br>CC8.1 - Change management | Automated security scanning in the CI/CD pipeline (SAST, SCA, secret detection) to identify and remediate vulnerabilities before they are deployed to production. See [SECURITY_CI.md](../SECURITY_CI.md) for details. |
 
 ## 3. Revision History
 


### PR DESCRIPTION
…ence

- Update SECURITY_CI.md to reflect Stripe v13 upgrade completion
- Add comprehensive CI Truth Table documenting all automated checks
- Map checks to actual workflow files (ci.yaml, docs-lint.yml, ci-security.yml)
- Clarify which checks fail PRs vs. informational only
- Update docs/README.md with CI Truth Table links and evidence locations
- Enhance SOC2 Control Mapping with additional TSC criteria and SECURITY_CI references
- Ensure documentation accurately mirrors current CI enforcement reality